### PR TITLE
add --version-string to set version explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ usage: help2man [-h] [-V] [--print-completion {bash,zsh,tcsh}] [-n NAME]
                 [-s SECTION] [-m MANUAL] [-S SOURCE] [-p INFO_PAGE]
                 [-i INCLUDE] [-o OUTPUT] [--template {man,markdown}]
                 [--template-file TEMPLATE_FILE] [--help-option HELP_OPTION]
-                [--version-option VERSION_OPTION] [--no-discard-stderr]
+                [--version-option VERSION_OPTION] [--version-string VERSION]
+                [--no-discard-stderr]
                 executable ...
 
 Convert --help and --version to man page.
@@ -82,7 +83,8 @@ SYNOPSIS
                 [-s SECTION] [-m MANUAL] [-S SOURCE] [-p INFO_PAGE]
                 [-i INCLUDE] [-o OUTPUT] [--template {man,markdown}]
                 [--template-file TEMPLATE_FILE] [--help-option HELP_OPTION]
-                [--version-option VERSION_OPTION] [--no-discard-stderr]
+                [--version-option VERSION_OPTION] [--version-string VERSION]
+                [--no-discard-stderr]
                 executable ...
 
 DESCRIPTION
@@ -134,7 +136,8 @@ help2man [-h] [-V] [----print-completion {bash,zsh,tcsh}] [-n NAME]
          [-s SECTION] [-m MANUAL] [-S SOURCE] [-p INFO_PAGE]
          [-i INCLUDE] [-o OUTPUT] [----template {man,markdown}]
          [----template-file TEMPLATE_FILE] [----help-option HELP_OPTION]
-         [----version-option VERSION_OPTION] [----no-discard-stderr]
+         [----version-option VERSION_OPTION] [----version-string VERSION]
+         [----no-discard-stderr]
          executable ...
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -43,22 +43,22 @@ Convert `--help` and `--version` to man page or other file types like markdown.
 ```sh
 $ help2man --help
 usage: help2man [-h] [-V] [--print-completion {bash,zsh,tcsh}] [-n NAME]
-                [-s SECTION] [-m MANUAL] [-S SOURCE] [-p INFO_PAGE]
-                [-i INCLUDE] [-o OUTPUT] [--template {man,markdown}]
-                [--template-file TEMPLATE_FILE] [--help-option HELP_OPTION]
-                [--version-option VERSION_OPTION] [--version-string VERSION]
-                [--no-discard-stderr]
-                executable ...
+[-s SECTION] [-m MANUAL] [-S SOURCE] [-p INFO_PAGE]
+[-i INCLUDE] [-o OUTPUT] [--template {man,markdown}]
+[--template-file TEMPLATE_FILE] [--help-option HELP_OPTION]
+[--version-option VERSION_OPTION] [--version-string VERSION]
+[--no-discard-stderr]
+executable ...
 
 Convert --help and --version to man page.
 
 positional arguments:
-  executable            executable program name
-  ...                   executable program arguments
+executable            executable program name
+...                   executable program arguments
 
 options:
-  -h, --help            show this help message and exit
-  -V, --version         show program's version number and exit
+-h, --help            show this help message and exit
+-V, --version         show program's version number and exit
 # ...
 $ help2man --version
 help2man 0.0.9

--- a/src/help2man/__main__.py
+++ b/src/help2man/__main__.py
@@ -85,6 +85,12 @@ def get_parser() -> ArgumentParser:
         help="version option string, default: %(default)s",
     )
     parser.add_argument(
+        "--version-string",
+        dest="versionstr",
+        metavar="VERSION",
+        help="force version string",
+    )
+    parser.add_argument(
         "--no-discard-stderr",
         action="store_true",
         help="include stderr when parsing option output",

--- a/src/help2man/ui/__init__.py
+++ b/src/help2man/ui/__init__.py
@@ -38,7 +38,10 @@ def init(args: Namespace) -> Namespace:
     help_tokens = args.executable + args.args + split(args.help_option)
     version_tokens = args.executable + args.args + split(args.version_option)
     args.helpstr = get_cmd_output(help_tokens, args.no_discard_stderr)
-    args.versionstr = get_cmd_output(version_tokens, args.no_discard_stderr)
+    if not args.versionstr:
+        args.versionstr = get_cmd_output(
+            version_tokens, args.no_discard_stderr
+        )
     if args.include:
         try:
             with open(args.include) as f:

--- a/tests/txt/options.txt
+++ b/tests/txt/options.txt
@@ -29,4 +29,6 @@ options:
                         help option string, default: --help
   --version-option VERSION_OPTION
                         version option string, default: --version
+  --version-string VERSION
+                        force version string
   --no-discard-stderr   include stderr when parsing option output

--- a/tests/txt/usage.txt
+++ b/tests/txt/usage.txt
@@ -2,5 +2,6 @@ usage: help2man [-h] [-V] [--print-completion {bash,zsh,tcsh}] [-n NAME]
                 [-s SECTION] [-m MANUAL] [-S SOURCE] [-p INFO_PAGE]
                 [-i INCLUDE] [-o OUTPUT] [--template {man,markdown}]
                 [--template-file TEMPLATE_FILE] [--help-option HELP_OPTION]
-                [--version-option VERSION_OPTION] [--no-discard-stderr]
+                [--version-option VERSION_OPTION] [--version-string VERSION]
+                [--no-discard-stderr]
                 executable ...


### PR DESCRIPTION
This matches the GNU help2man option.  It's helpful when the tool's --version output doesn't match what help2man expects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new optional command-line argument `--version-string` that allows users to specify a custom version string.
- **Documentation**
  - Updated usage and options documentation to include the new `--version-string` argument.
  - Improved formatting and alignment in the usage section for better readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->